### PR TITLE
Reverted to 1.5.x version of rackspace/php-opencloud

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     , "require": {
           "php": ">=5.3.0"
         , "illuminate/support": "4.0.x"
-        , "rackspace/php-opencloud": "dev-master#f8eb7d3d3b277aeb909af1e6569cc2744e1e547c"
+        , "rackspace/php-opencloud": "1.5.x"
         , "alchemy/zippy": "0.1.0"
     }
     , "autoload": {


### PR DESCRIPTION
The 1.5.x (1.5.10 latest) is working for us
