### PR TITLE
Add trailing slash if missing

### DIFF
--- a/src/Thomaswelton/LaravelRackspaceOpencloud/UrlGenerator.php
+++ b/src/Thomaswelton/LaravelRackspaceOpencloud/UrlGenerator.php
@@ -21,6 +21,10 @@ class UrlGenerator extends LaravelGenerator{
         // Look up through the directories looking for a
         // CDN json file
         while($checkDir !== public_path()){
+        
+            if ($checkDir[strlen($checkDir) - 1] !== DIRECTORY_SEPARATOR)
+            	$checkDir .= DIRECTORY_SEPARATOR;
+        	
             $cdnJsonPath = $checkDir . '.cdn.json';
 
             if(File::isFile($cdnJsonPath)){


### PR DESCRIPTION
$checkDir did not contain a trailing slash on OS X Yosemite so $cdnJsonPath was '.../path/to.cdn.json' instead of '.../path/to/.cdn.json'

Haven't had a chance to test it elsewhere.
