### PR TITLE
Allow setting RAXSDK_TIMEOUT, but define default timeout if not previously defined

### DIFF
--- a/src/Thomaswelton/LaravelRackspaceOpencloud/OpenCloud.php
+++ b/src/Thomaswelton/LaravelRackspaceOpencloud/OpenCloud.php
@@ -4,10 +4,7 @@ use \Config;
 use \File;
 use Alchemy\Zippy\Zippy;
 
-// default 5 minutes if not already defined
-if(!defined('RAXSDK_TIMEOUT')){
-    define('RAXSDK_TIMEOUT', 300);
-}
+define('RAXSDK_TIMEOUT', Config::get('laravel-rackspace-opencloud::raxsdk_timeout'));
 
 class OpenCloud extends \OpenCloud\Rackspace{
 

--- a/src/Thomaswelton/LaravelRackspaceOpencloud/OpenCloud.php
+++ b/src/Thomaswelton/LaravelRackspaceOpencloud/OpenCloud.php
@@ -4,8 +4,10 @@ use \Config;
 use \File;
 use Alchemy\Zippy\Zippy;
 
-// 5 minutes
-define('RAXSDK_TIMEOUT', 600);
+// default 5 minutes if not already defined
+if(!defined('RAXSDK_TIMEOUT')){
+    define('RAXSDK_TIMEOUT', 300);
+}
 
 class OpenCloud extends \OpenCloud\Rackspace{
 

--- a/src/Thomaswelton/LaravelRackspaceOpencloud/OpenCloud.php
+++ b/src/Thomaswelton/LaravelRackspaceOpencloud/OpenCloud.php
@@ -5,7 +5,7 @@ use \File;
 use Alchemy\Zippy\Zippy;
 
 // 5 minutes
-define('RAXSDK_TIMEOUT', 300);
+define('RAXSDK_TIMEOUT', 600);
 
 class OpenCloud extends \OpenCloud\Rackspace{
 

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -4,5 +4,6 @@ return array(
 	'region' => 'RACKSPACE_REGION',
 	'username' => 'RACKSPACE_USERNAME',
 	'apiKey' => 'RACKSPACE_API_KEY',
-    'container' => 'DEFUALT_CONTAINER_NAME'
+    	'container' => 'DEFUALT_CONTAINER_NAME',
+    	'raxsdk_timeout' => 300
 );


### PR DESCRIPTION
I needed to over-ride the 5 minute time-out (we have people uploading large videos)

This allows me to place the define() command in my own code, and have it take precedence over the definition in OpenCloud, which is still needed by anyone who hasn't otherwise defined it.

If you can think of a better way, I'm open to suggestions

Thanks!
